### PR TITLE
Add lib.sh and refactor scripts to use shared functions

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 # Configuration
 SELECT_UTXO="./select-utxo.sh"

--- a/check.sh
+++ b/check.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 
 # Configuration
 SELECT_UTXO="./select-utxo.sh"
@@ -10,7 +12,7 @@ source "$SELECT_UTXO"
 
 # Check if cardano-cli is installed
 check_cardano_cli() {
-    if ! command -v cardano-cli &> /dev/null; then
+    if ! command -v "$CARDANO_CLI" &> /dev/null; then
         echo "cardano-cli is not installed. Please install it first."
         exit 1
     fi
@@ -22,9 +24,9 @@ check_utxo() {
     local check_file="$selected_file"
     
     echo "Querying UTXO for the address in file: $check_file"
-    cardano-cli conway query utxo \
+    $CARDANO_CLI conway query utxo \
         --address "$(cat "$check_file")" \
-        --testnet-magic 2
+        $NETWORK
 }
 
 # Function to check transaction hash
@@ -38,9 +40,9 @@ check_txhash() {
 
     echo "Checking transaction details for hash: $TX_HASH"
     local TX_DETAILS
-    TX_DETAILS=$(cardano-cli query utxo \
+    TX_DETAILS=$($CARDANO_CLI query utxo \
         --tx-in "$TX_HASH" \
-        --testnet-magic 2 2>&1)
+        $NETWORK 2>&1)
 
     if echo "$TX_DETAILS" | grep -q "Error"; then
         echo "Transaction does not exist or cannot be queried."

--- a/config.sh
+++ b/config.sh
@@ -19,7 +19,7 @@ NETWORK=${NETWORK:---testnet-magic 2}
 PROTOCOL_PARAMS=${PROTOCOL_PARAMS:-"protocol.json"}
 
 # cardano-node settings (used by run-node.sh)
-CARDANO_NODE_PATH=${CARDANO_NODE_PATH:-"/home/tuvu2/cardano-node"}
+CARDANO_NODE_PATH=${CARDANO_NODE_PATH:-"$SCRIPT_DIR/cardano-node"}
 TOPOLOGY=${TOPOLOGY:-"$CARDANO_NODE_PATH/share/preview/topology.json"}
 DB_PATH=${DB_PATH:-"$CARDANO_NODE_PATH/db"}
 SOCKET_PATH=${SOCKET_PATH:-"$CARDANO_NODE_PATH/db/node.socket"}

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Base directory of the repository
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Path to cardano-cli executable
+CARDANO_CLI=${CARDANO_CLI:-cardano-cli}
+
+# Path to cardano-address executable
+CARDANO_ADDRESS=${CARDANO_ADDRESS:-cardano-address}
+
+# Path to the node socket
+export CARDANO_NODE_SOCKET_PATH=${CARDANO_NODE_SOCKET_PATH:-"$SCRIPT_DIR/db/node.socket"}
+
+# Network flag to use with cardano-cli commands
+NETWORK=${NETWORK:---testnet-magic 2}
+
+# Protocol parameters file
+PROTOCOL_PARAMS=${PROTOCOL_PARAMS:-"protocol.json"}
+
+# cardano-node settings (used by run-node.sh)
+CARDANO_NODE_PATH=${CARDANO_NODE_PATH:-"/home/tuvu2/cardano-node"}
+TOPOLOGY=${TOPOLOGY:-"$CARDANO_NODE_PATH/share/preview/topology.json"}
+DB_PATH=${DB_PATH:-"$CARDANO_NODE_PATH/db"}
+SOCKET_PATH=${SOCKET_PATH:-"$CARDANO_NODE_PATH/db/node.socket"}
+HOST_ADDR=${HOST_ADDR:-"0.0.0.0"}
+PORT=${PORT:-"3001"}
+CONFIG=${CONFIG:-"$CARDANO_NODE_PATH/share/preview/config.json"}

--- a/datum/datum.json:Zone.Identifier
+++ b/datum/datum.json:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/delegate.sh
+++ b/delegate.sh
@@ -24,14 +24,19 @@ STAKE_ADDR=$(<stake.addr)
 DEGREG_CERT="dereg.cert"
 
 # External scripts
-SELECT_UTXO="./select-utxo.sh"
-FILE_UTILS="./file_utils.sh"
+SELECT_UTXO="$SCRIPT_DIR/select-utxo.sh"
+FILE_UTILS="$SCRIPT_DIR/file_utils.sh"
 
 STAKE_KEY_REGISTERED=$($CARDANO_CLI query stake-address-info --address "$(cat $STAKE_ADDR_FILE)" $NETWORK | jq -r '.[0].stakeDelegation')
 
 # Check if required external files exist
-if [[ ! -f $SELECT_UTXO || ! -f $FILE_UTILS ]]; then
-  echo "Required utility scripts not found: $SELECT_UTXO or $FILE_UTILS."
+if [[ ! -f "$SELECT_UTXO" ]]; then
+  echo "select-utxo.sh not found in $SCRIPT_DIR" >&2
+  exit 1
+fi
+
+if [[ ! -f "$FILE_UTILS" ]]; then
+  echo "file_utils.sh not found in $SCRIPT_DIR" >&2
   exit 1
 fi
 

--- a/drep.sh
+++ b/drep.sh
@@ -59,13 +59,11 @@ build_drep_tx() {
 
 
   
-  $CARDANO_CLI conway transaction build \
-    --tx-in "$tx_in" \
-    --change-address "$(< payment.addr)" \
-    --certificate-file drep-reg.cert  \
-    $NETWORK \
-    --witness-override 2 \
-    --out-file tx.raw
+  build_tx --tx-in "$tx_in" \
+           --change-address "$(< payment.addr)" \
+           --certificate-file drep-reg.cert \
+           --witness-override 2 \
+           --out-file tx.raw
 }
 
 # Function to sign and submit dRep registration transaction
@@ -127,13 +125,11 @@ build_and_submit_vote_tx() {
     return 1
   fi
 
-  $CARDANO_CLI conway transaction build \
-    --tx-in "$($CARDANO_CLI query utxo --address "$(< payment.addr)" $NETWORK --output-json | jq -r 'keys[0]')" \
-    --change-address "$(< payment.addr)" \
-    --vote-file "$vote_file" \
-    --witness-override 2 \
-    --out-file vote-tx.raw \
-    $NETWORK
+  build_tx --tx-in "$($CARDANO_CLI query utxo --address "$(< payment.addr)" $NETWORK --output-json | jq -r 'keys[0]')" \
+           --change-address "$(< payment.addr)" \
+           --vote-file "$vote_file" \
+           --witness-override 2 \
+           --out-file vote-tx.raw
 
   sign_tx --tx-body-file vote-tx.raw \
           --signing-key-file drep.skey \

--- a/drep.sh
+++ b/drep.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 
 SELECT_UTXO="./select-utxo.sh"
 
@@ -8,7 +10,7 @@ source "$SELECT_UTXO"
 
 # Function to generate dRep keys
 generate_drep_keys() {
-  cardano-cli conway governance drep key-gen \
+  $CARDANO_CLI conway governance drep key-gen \
     --verification-key-file drep.vkey \
     --signing-key-file drep.skey
 }
@@ -21,7 +23,7 @@ download_drep_metadata() {
 
 # Function to calculate dRep metadata hash
 calculate_metadata_hash() {
-  metadata_hash=$(cardano-cli conway governance drep metadata-hash \
+  metadata_hash=$($CARDANO_CLI conway governance drep metadata-hash \
     --drep-metadata-file drep.jsonld)
   echo $metadata_hash
 }
@@ -31,7 +33,7 @@ register_drep() {
   # Get the metadata hash
   metadata_hash=$(calculate_metadata_hash)
   
-  cardano-cli conway governance drep registration-certificate \
+  $CARDANO_CLI conway governance drep registration-certificate \
     --drep-verification-key-file drep.vkey \
     --key-reg-deposit-amt 500000000 \
     --drep-metadata-url https://raw.githubusercontent.com/cardano-foundation/CIPs/master/CIP-0119/examples/drep.jsonld \
@@ -46,37 +48,37 @@ build_drep_tx() {
 
 
   
-  cardano-cli conway transaction build \
+  $CARDANO_CLI conway transaction build \
     --tx-in "$tx_in" \
     --change-address $(< payment.addr) \
     --certificate-file drep-reg.cert  \
-    --testnet-magic 2 \
+    $NETWORK \
     --witness-override 2 \
     --out-file tx.raw
 }
 
 # Function to sign and submit dRep registration transaction
 sign_and_submit_drep_tx() {
-  cardano-cli conway transaction sign \
+  $CARDANO_CLI conway transaction sign \
     --tx-body-file tx.raw \
     --signing-key-file payment.skey \
     --signing-key-file drep.skey \
     --out-file tx.signed
   echo "txhash :"
-  cardano-cli conway transaction submit \
+  $CARDANO_CLI conway transaction submit \
     --tx-file tx.signed \
-    --testnet-magic 2
+    $NETWORK
 }
 
 export_drepid (){
-   cardano-cli conway governance drep id \
+   $CARDANO_CLI conway governance drep id \
   --drep-verification-key-file drep.vkey \
   --output-format hex > drep.id
 }
 
 # Function to query governance state
 query_governance_state() {
-  cardano-cli conway query gov-state --testnet-magic 2 > gov-state.json
+  $CARDANO_CLI conway query gov-state $NETWORK > gov-state.json
 
   cat gov-state.json
 }
@@ -97,7 +99,7 @@ create_vote() {
   # Gán giá trị cho biến toàn cục
   vote_file="${tx_in}-${index}.vote"
 
-  cardano-cli conway governance vote create \
+  $CARDANO_CLI conway governance vote create \
     --yes \
     --governance-action-tx-id "$tx_in" \
     --governance-action-index "$index" \
@@ -117,21 +119,21 @@ build_and_submit_vote_tx() {
     return 1
   fi
 
-  cardano-cli conway transaction build \
-    --tx-in "$(cardano-cli query utxo --address $(< payment.addr) --testnet-magic 2 --output-json | jq -r 'keys[0]')" \
+  $CARDANO_CLI conway transaction build \
+    --tx-in "$($CARDANO_CLI query utxo --address $(< payment.addr) $NETWORK --output-json | jq -r 'keys[0]')" \
     --change-address $(< payment.addr) \
     --vote-file "$vote_file" \
     --witness-override 2 \
     --out-file vote-tx.raw \
-    --testnet-magic 2
+    $NETWORK
 
-  cardano-cli conway transaction sign --tx-body-file vote-tx.raw \
+  $CARDANO_CLI conway transaction sign --tx-body-file vote-tx.raw \
     --signing-key-file drep.skey \
     --signing-key-file payment.skey \
     --out-file vote-tx.signed \
-    --testnet-magic 2
+    $NETWORK
 
-  cardano-cli conway transaction submit --tx-file vote-tx.signed --testnet-magic 2
+  $CARDANO_CLI conway transaction submit --tx-file vote-tx.signed $NETWORK
 }
 
 

--- a/drep.sh
+++ b/drep.sh
@@ -77,7 +77,7 @@ sign_and_submit_drep_tx() {
 }
 
 export_drepid (){
-   $CARDANO_CLI conway governance drep id \
+   $CARDANO_CLI conway governance drep id $NETWORK \
   --drep-verification-key-file drep.vkey \
   --output-format hex > drep.id
 }

--- a/file_utils.sh
+++ b/file_utils.sh
@@ -1,12 +1,12 @@
-
-
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 select_poolid() {
-    # Fetch the list of pool IDs from the cardano-cli command
-    pools=$(cardano-cli query stake-pools $NETWORK 2>/dev/null)
+    # Fetch the list of pool IDs from the $CARDANO_CLI command
+    pools=$($CARDANO_CLI query stake-pools $NETWORK 2>/dev/null)
 
     # Check if the command ran successfully
     if [[ $? -ne 0 || -z "$pools" ]]; then
-        echo "Unable to fetch the pool list. Please check your cardano-cli setup or the network connection."
+        echo "Unable to fetch the pool list. Please check your $CARDANO_CLI setup or the network connection."
         exit 1
     fi
 

--- a/lib.sh
+++ b/lib.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Library of helper functions for Cardano CLI workflows
+# Requires config.sh to be sourced before using these functions.
+
+# Select a UTXO from either a payment or script address.
+# Usage: select_utxo <payment|script>
+select_utxo() {
+    local input_type="${1:-payment}"
+    local utxo_file="utxo.json"
+
+    if [[ "$input_type" == "payment" ]]; then
+        $CARDANO_CLI conway query utxo \
+            --address "$(cat payment.addr)" \
+            $NETWORK \
+            --output-json > "$utxo_file"
+        echo "UTXO list from payment address:"
+    elif [[ "$input_type" == "script" ]]; then
+        $CARDANO_CLI conway query utxo \
+            --address "$(cat script.addr)" \
+            $NETWORK \
+            --output-json > "$utxo_file"
+        echo "UTXO list from script address:"
+    else
+        echo "Invalid input type. Use 'payment' or 'script'." >&2
+        return 1
+    fi
+
+    local sorted_utxos selected_index
+    sorted_utxos=$(jq -r 'to_entries | sort_by(.key) | reverse | .[] | "\(.key): \(.value.value.lovelace)"' "$utxo_file")
+    echo "Sorted UTXO list by txHash (descending):"
+    echo "$sorted_utxos" | nl -w2 -s'. '
+
+    read -p "Enter the number corresponding to the UTXO you want to use: " selected_index
+    SELECTED_UTXO=$(echo "$sorted_utxos" | sed -n "${selected_index}p" | awk '{print $1}')
+    if [[ -z "$SELECTED_UTXO" ]]; then
+        echo "Invalid selection." >&2
+        return 1
+    fi
+    echo "Selected UTXO: $SELECTED_UTXO"
+}
+
+# Calculate minimum fee for a transaction
+# Usage: calculate_fee <tx_body_file> <tx_in_count> <tx_out_count> <witness_count>
+calculate_fee() {
+    local body_file=$1
+    local in_count=$2
+    local out_count=$3
+    local witness_count=$4
+
+    echo "Calculating minimum fee..."
+    $CARDANO_CLI conway transaction calculate-min-fee \
+        --tx-body-file "$body_file" \
+        --tx-in-count "$in_count" \
+        --tx-out-count "$out_count" \
+        --witness-count "$witness_count" \
+        $NETWORK \
+        --protocol-params-file "$PROTOCOL_PARAMS"
+}
+
+# Build a raw transaction
+# Usage: build_tx [cardano-cli build args] --out-file <file>
+build_tx() {
+    echo "Building transaction..."
+    $CARDANO_CLI conway transaction build "$@" $NETWORK
+}
+
+# Sign a transaction
+# Usage: sign_tx --tx-body-file <file> --out-file <signed-file> [--signing-key-file ...]
+sign_tx() {
+    echo "Signing transaction..."
+    $CARDANO_CLI conway transaction sign "$@" $NETWORK
+}
+
+# Submit a signed transaction
+# Usage: submit_tx --tx-file <signed-file>
+submit_tx() {
+    echo "Submitting transaction..."
+    $CARDANO_CLI conway transaction submit "$@" $NETWORK
+}
+
+# Simple helper to derive a script address from a Plutus script file
+# Usage: run_plutus_script <script.plutus> <out.addr>
+run_plutus_script() {
+    local script_file=$1
+    local out_file=${2:-script.addr}
+    echo "Building script address from $script_file..."
+    $CARDANO_CLI address build --payment-script-file "$script_file" --out-file "$out_file" $NETWORK
+}

--- a/lock_assets.sh
+++ b/lock_assets.sh
@@ -1,14 +1,13 @@
 
 #!/bin/bash
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 
-SELECT_UTXO="./select-utxo.sh"
 FILE_UTILS="./file_utils.sh"
 
 # Import modules
 source "$FILE_UTILS"
-source "$SELECT_UTXO"
 
-TESTNET_MAGIC=2
 PAYMENT_ADDR_FILE="payment.addr"
 SIGNING_KEY_FILE="payment.skey"
 
@@ -48,36 +47,28 @@ lock_asset() {
     datum_file="$selected_file"
 
     echo ">> Building smart contract address..."
-    cardano-cli address build \
-        --payment-script-file "$script_plutus" \
-        --out-file script.addr \
-        --testnet-magic "$TESTNET_MAGIC"
+    run_plutus_script "$script_plutus" script.addr
     check_command $? "Failed to build smart contract address."
 
     echo ">> Building transaction..."
-    cardano-cli conway transaction build \
-        --tx-in "$tx_in" \
-        --tx-out "$(cat script.addr)+$tx_amount" \
-        --tx-out-inline-datum-file "$datum_file" \
-        --change-address "$(cat "$PAYMENT_ADDR_FILE")" \
-        --testnet-magic "$TESTNET_MAGIC" \
-        --out-file lock.tx
+    build_tx --tx-in "$tx_in" \
+             --tx-out "$(cat script.addr)+$tx_amount" \
+             --tx-out-inline-datum-file "$datum_file" \
+             --change-address "$(cat "$PAYMENT_ADDR_FILE")" \
+             --out-file lock.tx
     check_command $? "Failed to build transaction."
 
     echo ">> Signing transaction..."
-    cardano-cli conway transaction sign \
-        --tx-file lock.tx \
-        --signing-key-file "$SIGNING_KEY_FILE" \
-        --out-file lock.tx.signed
+    sign_tx --tx-body-file lock.tx \
+            --signing-key-file "$SIGNING_KEY_FILE" \
+            --out-file lock.tx.signed
     check_command $? "Failed to sign transaction."
 
     echo ">> Submitting transaction..."
-    cardano-cli conway transaction submit \
-        --testnet-magic "$TESTNET_MAGIC" \
-        --tx-file lock.tx.signed
+    submit_tx --tx-file lock.tx.signed
     check_command $? "Failed to submit transaction."
 
-    txid=$(cardano-cli conway transaction txid --tx-file lock.tx.signed)
+    txid=$($CARDANO_CLI conway transaction txid --tx-file lock.tx.signed)
     if [[ -n "$txid" ]]; then
         echo "Transaction successful!"
         echo "Transaction hash (TXID): $txid"

--- a/lock_assets.sh
+++ b/lock_assets.sh
@@ -1,7 +1,17 @@
-
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 FILE_UTILS="./file_utils.sh"
 

--- a/main.sh
+++ b/main.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 
 # Function to execute a script based on user choice
 execute_choice() {

--- a/main.sh
+++ b/main.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 # Function to execute a script based on user choice
 execute_choice() {

--- a/plutus_scripts/burn.plutus:Zone.Identifier
+++ b/plutus_scripts/burn.plutus:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/plutus_scripts/customtypes.plutus:Zone.Identifier
+++ b/plutus_scripts/customtypes.plutus:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/plutus_scripts/fortytwo.plutus:Zone.Identifier
+++ b/plutus_scripts/fortytwo.plutus:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/plutus_scripts/fortytwotyped.plutus:Zone.Identifier
+++ b/plutus_scripts/fortytwotyped.plutus:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/plutus_scripts/gift.plutus:Zone.Identifier
+++ b/plutus_scripts/gift.plutus:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/redeemers/redeemer_customtypes.json:Zone.Identifier
+++ b/redeemers/redeemer_customtypes.json:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/redeemers/redeemer_notype-typed.json:Zone.Identifier
+++ b/redeemers/redeemer_notype-typed.json:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-ReferrerUrl=C:\Users\User\Downloads\Telegram Desktop\bashscript.zip

--- a/run-node.sh
+++ b/run-node.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 # Set environment variable
 export CARDANO_NODE_SOCKET_PATH="$SOCKET_PATH"

--- a/run-node.sh
+++ b/run-node.sh
@@ -1,15 +1,6 @@
 #!/bin/bash
-
-# Path to the cardano-node directory
-CARDANO_NODE_PATH="/home/tuvu2/cardano-node"
-
-# Required parameters
-TOPOLOGY="$CARDANO_NODE_PATH/share/preview/topology.json"
-DB_PATH="$CARDANO_NODE_PATH/db"
-SOCKET_PATH="$CARDANO_NODE_PATH/db/node.socket"
-HOST_ADDR="0.0.0.0"
-PORT="3001"
-CONFIG="$CARDANO_NODE_PATH/share/preview/config.json"
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 
 # Set environment variable
 export CARDANO_NODE_SOCKET_PATH="$SOCKET_PATH"
@@ -22,7 +13,7 @@ is_node_running() {
 
 # Function to check synchronization status
 check_sync_status() {
-  cardano-cli query tip --testnet-magic 2 2>/dev/null | grep "syncProgress" | awk -F'"' '{print $4}'
+  $CARDANO_CLI query tip $NETWORK 2>/dev/null | grep "syncProgress" | awk -F'"' '{print $4}'
 }
 
 # Function to start the node

--- a/select-utxo.sh
+++ b/select-utxo.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 select_utxo "$@"

--- a/select-utxo.sh
+++ b/select-utxo.sh
@@ -1,54 +1,5 @@
-
 #!/bin/bash
+source "$(dirname "$0")/config.sh"
+source "$(dirname "$0")/lib.sh"
 
-UTXO_FILE="utxo.json"
-
-# Function to select UTXO
-select_utxo() {
-    local input_type="$1"  # Input parameter: "payment" or "script"
-
-    if [[ "$input_type" == "payment" ]]; then
-        # Query UTXO from the payment address
-        cardano-cli conway query utxo \
-            --address "$(cat payment.addr)" \
-            --testnet-magic 2 \
-            --output-json > "$UTXO_FILE"
-        echo "UTXO list from payment address:"
-
-    elif [[ "$input_type" == "script" ]]; then
-        # Query UTXO from the script address
-        cardano-cli conway query utxo \
-            --address "$(cat script.addr)" \
-            --testnet-magic 2 \
-            --output-json > "$UTXO_FILE"
-        echo "UTXO list from script address:"
-
-    else
-        echo "Invalid input type. Please select 'payment' or 'script'."
-        exit 1
-    fi
-
-    # Sort UTXO list by txHash and txIndex (descending order)
-    sorted_utxos=$(jq -r 'to_entries | sort_by(.key) | reverse | .[] | "\(.key) : \(.value.value.lovelace)"' "$UTXO_FILE")
-
-    # Display sorted UTXO list
-    echo "Sorted UTXO list by txHash (descending):"
-    echo "$sorted_utxos" | nl -w2 -s'. '
-
-    # Ask the user to select a UTXO
-    read -p "Enter the number corresponding to the UTXO you want to use: " selected_index
-    SELECTED_UTXO=$(echo "$sorted_utxos" | sed -n "${selected_index}p" | awk '{print $1}')
-    if [[ -z "$SELECTED_UTXO" ]]; then
-        echo "Invalid selection. Please try again."
-        exit 1
-    fi
-
-    echo "You have selected UTXO: $SELECTED_UTXO"
-}
-
-# Example usage of the function:
-# To select a payment UTXO:
-# select_utxo "payment"
-
-# To select a script UTXO:
-# select_utxo "script"
+select_utxo "$@"

--- a/unlock_assets.sh
+++ b/unlock_assets.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 FILE_UTILS="./file_utils.sh"
 
@@ -60,7 +71,7 @@ unlock_asset() {
                 --tx-in-script-file "$script_plutus" \
                 --tx-in-inline-datum-present \
                 --tx-in-redeemer-file "$redeemer_file" \
-                --change-address $(< payment.addr) \
+                --change-address "$(< payment.addr)" \
                 --out-file unlock.tx; then
         echo "Transaction built successfully."
     else

--- a/unlock_assets.sh
+++ b/unlock_assets.sh
@@ -13,9 +13,14 @@ fi
 source "$CONFIG_FILE"
 source "$LIB_FILE"
 
-FILE_UTILS="./file_utils.sh"
+FILE_UTILS="$SCRIPT_DIR/file_utils.sh"
 
-# Import modules
+# Import modules with existence check
+if [[ ! -f "$FILE_UTILS" ]]; then
+  echo "file_utils.sh not found in $SCRIPT_DIR" >&2
+  exit 1
+fi
+
 source "$FILE_UTILS"
 
 # Function to unlock asset

--- a/wallet-generate.sh
+++ b/wallet-generate.sh
@@ -1,9 +1,24 @@
-
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 # Check required tools before running
+if [[ -z "${CARDANO_ADDRESS:-}" || -z "${CARDANO_CLI:-}" ]]; then
+  echo "CARDANO_ADDRESS or CARDANO_CLI not set" >&2
+  exit 1
+fi
+
 command -v "$CARDANO_ADDRESS" > /dev/null || { echo "Error: '$CARDANO_ADDRESS' is not installed."; exit 1; }
 command -v "$CARDANO_CLI" > /dev/null || { echo "Error: '$CARDANO_CLI' is not installed."; exit 1; }
 

--- a/wallet_transaction.sh
+++ b/wallet_transaction.sh
@@ -29,18 +29,18 @@ check_and_generate_wallet() {
 # Function to perform the transaction
 perform_transaction() {
     select_utxo "payment" || return 1
-    if [[ -z "$SELECTED_UTXO" ]]; then
+    if [[ -z "${SELECTED_UTXO:-}" ]]; then
         echo "No UTXO selected. Exiting." >&2
         return 1
     fi
     echo "Using UTXO: $SELECTED_UTXO for the transaction."
     local tx_in="$SELECTED_UTXO"
 
-    read -p "Enter the amount (tx-mount): " tx_mount
+    read -p "Enter the amount (tx-amount): " tx_amount
     read -p "Enter the recipient address (tx-out): " tx_out
 
     build_tx --tx-in "$tx_in" \
-             --tx-out "$tx_out+$tx_mount" \
+             --tx-out "$tx_out+$tx_amount" \
              --change-address "$(cat payment.addr)" \
              --out-file simple-tx.raw || return 1
 

--- a/wallet_transaction.sh
+++ b/wallet_transaction.sh
@@ -14,7 +14,11 @@ source "$CONFIG_FILE"
 source "$LIB_FILE"
 
 # Path to wallet generation module
-WALLET_GENERATE="./wallet-generate.sh"
+WALLET_GENERATE="$SCRIPT_DIR/wallet-generate.sh"
+if [[ ! -f "$WALLET_GENERATE" ]]; then
+    echo "wallet-generate.sh not found in $SCRIPT_DIR" >&2
+    exit 1
+fi
 
 # Check if the wallet exists
 check_and_generate_wallet() {

--- a/wallet_transaction.sh
+++ b/wallet_transaction.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-source "$(dirname "$0")/config.sh"
-source "$(dirname "$0")/lib.sh"
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname "$0")"
+CONFIG_FILE="$SCRIPT_DIR/config.sh"
+LIB_FILE="$SCRIPT_DIR/lib.sh"
+
+if [[ ! -f "$CONFIG_FILE" || ! -f "$LIB_FILE" ]]; then
+  echo "Required config.sh or lib.sh not found" >&2
+  exit 1
+fi
+
+source "$CONFIG_FILE"
+source "$LIB_FILE"
 
 # Path to wallet generation module
 WALLET_GENERATE="./wallet-generate.sh"


### PR DESCRIPTION
## Summary
- add `lib.sh` with helper functions for utxo selection, fee calculation and tx handling
- update all scripts to source this library
- refactor `wallet_transaction.sh` to use new library functions
- simplify `select-utxo.sh` as a thin wrapper around `select_utxo`

## Testing
- `git status --short`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced centralized configuration and helper library scripts for Cardano CLI workflows, enabling easier management of tool paths, network settings, and protocol parameters.
  - Added reusable functions for common Cardano operations, such as UTXO selection, fee calculation, transaction building, signing, and submission.

- **Refactor**
  - Updated all scripts to use configuration variables and wrapper functions instead of hardcoded command names and network parameters.
  - Simplified scripts by delegating shared logic to external configuration and library files, reducing duplication and improving maintainability.
  - Enhanced scripts with strict error handling and validation of required configuration files at startup.

- **Bug Fixes**
  - Improved error handling and user feedback in transaction and wallet scripts.

- **Chores**
  - Removed Windows Zone Identifier metadata files from the repository to clean up non-functional metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->