### PR TITLE
Switch menu to dialog

### DIFF
--- a/.dialogrc
+++ b/.dialogrc
@@ -1,0 +1,8 @@
+# ~/.dialogrc for crd_cli-util4
+# Remove shadows, use a flat white-on-black style with cyan titles
+shadow = off
+widget_color = white,black
+title_color = cyan,black
+border_color = white,black
+# Enable ANSI color tags in dialog text
+colors = on


### PR DESCRIPTION
## Summary
- add `.dialogrc` for dialog theme customization
- migrate `menu.sh` from `whiptail` to `dialog`

## Testing
- `bash -n menu.sh`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new menu interface with an updated visual style, including a flat color scheme and improved readability.
	- Expanded menu options to include "Check UTxO," "Send ADA," "Delegate Stake," "Register/Update DRep," "Lock Assets," and "Unlock Assets."
- **Improvements**
	- Enhanced user experience with clearer option selection and colored dialog output.
- **Other**
	- Menu now runs once per invocation instead of looping continuously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->