### PR TITLE
Add GUI scaffolding with wallet security

### DIFF
--- a/crd_cli-gui/config.sh
+++ b/crd_cli-gui/config.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export CARDANO_CLI="${CARDANO_CLI:-cardano-cli}"
+export NETWORK="${NETWORK:---testnet-magic 2}"
+export PROTOCOL_PARAMS="${PROTOCOL_PARAMS:-$SCRIPT_DIR/protocol.json}"
+
+if [[ -z "${CARDANO_NODE_SOCKET_PATH:-}" ]]; then
+  DEFAULT_SOCKET="$(find "$HOME/cardano" -type s -name "*.socket" 2>/dev/null | head -n1)"
+  export CARDANO_NODE_SOCKET_PATH="${DEFAULT_SOCKET:-$SCRIPT_DIR/db/node.socket}"
+fi
+
+# Optional defaults for run-node.sh
+: "${DB_PATH:=$SCRIPT_DIR/db}"
+: "${TOPOLOGY:=$SCRIPT_DIR/configuration/testnet-topology.json}"
+: "${CONFIG:=$SCRIPT_DIR/configuration/testnet-config.json}"
+: "${HOST_ADDR:=0.0.0.0}"
+: "${PORT:=3001}"

--- a/crd_cli-gui/gui.sh
+++ b/crd_cli-gui/gui.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/lib.sh"
+
+while true; do
+  CHOICE=$(dialog --clear \
+    --backtitle "crd_cli-gui" \
+    --title "Main Menu" \
+    --menu "Select action:" 15 60 5 \
+      1 "Wallet Management" \
+      2 "Transactions" \
+      3 "Stake & Delegation" \
+      4 "Node Control" \
+      5 "Quit" \
+    2>&1 >/dev/tty)
+  case "$CHOICE" in
+    1) bash "$SCRIPT_DIR/wallet.sh"   ;;
+    2) bash "$SCRIPT_DIR/tx.sh"       ;;
+    3) bash "$SCRIPT_DIR/stake.sh"    ;;
+    4) bash "$SCRIPT_DIR/node.sh"     ;;
+    5) clear; exit 0                  ;;
+  esac
+done

--- a/crd_cli-gui/lib.sh
+++ b/crd_cli-gui/lib.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a new wallet (generate keys, encrypt seed, write to ~/.crd_cli-gui)
+create_wallet() {
+  mkdir -p "$HOME/.crd_cli-gui"
+  # ... generate keys, write encrypted seed to $HOME/.crd_cli-gui/seed.enc
+  echo "create_wallet not implemented" >&2
+}
+
+# Show the wallet address
+show_address() {
+  # ... read payment.addr or similar
+  echo "show_address not implemented" >&2
+}
+
+# Verify passphrase
+verify_passphrase() {
+  local pass="$1"
+  # return 0 if pass correct, 1 otherwise
+  return 1
+}
+
+# Decrypt and return the seed phrase
+get_seed_phrase() {
+  # ... decrypt $HOME/.crd_cli-gui/seed.enc in-memory
+  echo "your seed phrase here"
+}

--- a/crd_cli-gui/node.sh
+++ b/crd_cli-gui/node.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+while true; do
+  CHOICE=$(dialog --clear \
+    --backtitle "Node Control" \
+    --title "Node Menu" \
+    --menu "Select action:" 10 50 3 \
+      1 "Run Node" \
+      2 "Stop Node" \
+      3 "Back to Main Menu" \
+    2>&1 >/dev/tty)
+  case "$CHOICE" in
+    1)
+      bash "$ROOT_DIR/run-node.sh"
+      ;;
+    2)
+      pkill -f "cardano-node.*--database-path $DB_PATH" && \
+        dialog --msgbox "Node stopped" 6 40
+      ;;
+    3)
+      break
+      ;;
+  esac
+done

--- a/crd_cli-gui/stake.sh
+++ b/crd_cli-gui/stake.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+LOGFILE="$HOME/.crd_cli-gui/stake.log"
+mkdir -p "$(dirname "$LOGFILE")"
+
+while true; do
+  CHOICE=$(dialog --clear \
+    --backtitle "Stake & Delegation" \
+    --title "Stake Menu" \
+    --menu "Choose an operation:" 15 60 3 \
+      1 "Delegate / Withdraw" \
+      2 "Governance (dRep)" \
+      3 "Back to Main Menu" \
+    2>&1 >/dev/tty)
+  case "$CHOICE" in
+    1)
+      bash "$ROOT_DIR/delegate.sh" 2>&1 | tee -a "$LOGFILE"
+      ;;
+    2)
+      bash "$ROOT_DIR/drep.sh" 2>&1 | tee -a "$LOGFILE"
+      ;;
+    3)
+      break
+      ;;
+  esac
+done

--- a/crd_cli-gui/tx.sh
+++ b/crd_cli-gui/tx.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/config.sh"
+
+LOGFILE="$HOME/.crd_cli-gui/tx.log"
+mkdir -p "$(dirname "$LOGFILE")"
+
+while true; do
+  CHOICE=$(dialog --clear \
+    --backtitle "Transactions" \
+    --title "Transaction Menu" \
+    --menu "Select an option:" 15 60 4 \
+      1 "Send ADA" \
+      2 "Lock Assets" \
+      3 "Unlock Assets" \
+      4 "Back to Main Menu" \
+    2>&1 >/dev/tty)
+  case "$CHOICE" in
+    1)
+      bash "$ROOT_DIR/wallet_transaction.sh" 2>&1 | tee -a "$LOGFILE"
+      ;;
+    2)
+      bash "$ROOT_DIR/lock_assets.sh" 2>&1 | tee -a "$LOGFILE"
+      ;;
+    3)
+      bash "$ROOT_DIR/unlock_assets.sh" 2>&1 | tee -a "$LOGFILE"
+      ;;
+    4)
+      break
+      ;;
+  esac
+done

--- a/crd_cli-gui/wallet.sh
+++ b/crd_cli-gui/wallet.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/config.sh"
+source "$SCRIPT_DIR/lib.sh"
+
+LOGFILE="$HOME/.crd_cli-gui/wallet.log"
+mkdir -p "$(dirname "$LOGFILE")"
+
+while true; do
+  CHOICE=$(dialog --clear \
+    --backtitle "Wallet Management" \
+    --title "Wallet Menu" \
+    --menu "Choose an operation:" 15 60 5 \
+      1 "Create New Wallet" \
+      2 "View Wallet Address" \
+      3 "Reveal Seed Phrase" \
+      4 "View Wallet Logs" \
+      5 "Back to Main Menu" \
+    2>&1 >/dev/tty)
+  case "$CHOICE" in
+    1) create_wallet | tee -a "$LOGFILE" ;;
+    2) show_address  | tee -a "$LOGFILE" | dialog --msgbox "$(show_address)" 8 60 ;;
+    3)
+      PASS=$(dialog --insecure --passwordbox "Enter your wallet passphrase:" 8 60 2>&1 >/dev/tty)
+      if verify_passphrase "$PASS"; then
+        SEED=$(get_seed_phrase)
+        dialog --title "Seed Phrase" --msgbox "$SEED" 12 60
+      else
+        dialog --msgbox "Invalid passphrase" 6 40
+      fi
+      ;;
+    4)
+      dialog --title "Wallet Logs" --textbox "$LOGFILE" 20 70
+      ;;
+    5) break ;;
+  esac
+done


### PR DESCRIPTION
## Summary
- scaffold GUI scripts under `crd_cli-gui`
- add wallet helpers and configuration
- include placeholder scripts for future modules
- implement tx, stake, and node modules for GUI by invoking existing scripts

## Testing
- `bash check.sh` *(fails: syntax error in select-utxo.sh)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command-line graphical user interface (GUI) for managing Cardano CLI operations, including wallet management, transactions, staking, and node control.
  - Added interactive menus for wallet creation, address viewing, seed phrase retrieval, transaction actions (send ADA, lock/unlock assets), staking and delegation, and node start/stop controls.
  - Implemented logging for wallet, transaction, and staking activities for easier tracking and review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->